### PR TITLE
Update azuredeploy.json

### DIFF
--- a/Templates/azuredeploy.json
+++ b/Templates/azuredeploy.json
@@ -164,7 +164,7 @@
             "winRM": {
               "listeners": [
                 {
-                  "protocol": "http"
+                  "protocol": "https"
                 }
               ]
             },

--- a/Templates/azuredeploy.json
+++ b/Templates/azuredeploy.json
@@ -42,7 +42,7 @@
     },
     "imageSKU": {
       "type": "string",
-      "defaultValue": "2016-Technical-Preview-with-Containers",
+      "defaultValue": "2016-Datacenter-with-Containers",
       "metadata": {
         "description": "Image SKU"
       }

--- a/Templates/azuredeploy.json
+++ b/Templates/azuredeploy.json
@@ -164,7 +164,7 @@
             "winRM": {
               "listeners": [
                 {
-                  "protocol": "https"
+                  "protocol": "http"
                 }
               ]
             },


### PR DESCRIPTION
Looks like MS got rid of the 2016 Technical Preview image. I used this PS cmd to find available OS images in my region, and then changed the name accordingly: 

Get-AzureRMVMImageSku -Location "East US" -Publisher "MicrosoftWindowsServer" -Offer "WindowsServer" | Select Skus